### PR TITLE
Feature/fix str repr methods

### DIFF
--- a/pymaybe/__init__.py
+++ b/pymaybe/__init__.py
@@ -27,6 +27,12 @@ class Nothing(Maybe):
 
         return els
 
+    def or_none(self):
+        return self.or_else()
+
+    def or_empty_list(self):
+        return self.or_else([])
+
     def __call__(self, *args, **kwargs):
         return Nothing()
 
@@ -188,6 +194,12 @@ class Something(Maybe):
     # pylint: disable=W0613
     def or_else(self, els=None):
         return self.__value
+
+    def or_none(self):
+        return self.or_else()
+
+    def or_empty_list(self):
+        return self.or_else([])
 
     def __getattr__(self, name):
         try:

--- a/pymaybe/__init__.py
+++ b/pymaybe/__init__.py
@@ -471,10 +471,10 @@ def maybe(value):
     """Wraps an object with a Maybe instance.
 
       >>> maybe("I'm a value")
-      "I'm a value"
+      Something("I'm a value")
 
       >>> maybe(None);
-      None
+      Nothing
 
       Testing for value:
 
@@ -515,22 +515,22 @@ def maybe(value):
         eran = maybe(Person('eran'))
 
         >>> eran.name
-        'eran'
+        Something('eran')
         >>> eran.phone_number
-        None
+        Nothing
         >>> eran.phone_number.or_else('no phone number')
         'no phone number'
 
         >>> maybe(4) + 8
-        12
+        Something(12)
         >>> maybe(4) - 2
-        2
+        Something(2)
         >>> maybe(4) * 2
-        8
+        Something(8)
 
       And methods:
 
-        >>> maybe('VALUE').lower()
+        >>> maybe('VALUE').lower().get()
         'value'
         >>> maybe(None).invalid().method().or_else('unknwon')
         'unknwon'
@@ -548,10 +548,10 @@ def maybe(value):
             }
         })
 
-        >>> nested_dict['store']['name']
+        >>> nested_dict['store']['name'].get()
         'MyStore'
         >>> nested_dict['store']['address']
-        None
+        Nothing
         >>> nested_dict['store']['address']['street'].or_else('No Address Specified')
         'No Address Specified'
         >>> nested_dict['store']['departments']['sales']['head_count'].or_else('0')

--- a/pymaybe/__init__.py
+++ b/pymaybe/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = 'Eran Kampf'
 __email__ = 'eran@ekampf.com'
-__version__ = '0.1.6'
+__version__ = '0.1.7'
 
 from sys import getsizeof
 

--- a/pymaybe/__init__.py
+++ b/pymaybe/__init__.py
@@ -556,6 +556,10 @@ def maybe(value):
         Nothing
         >>> nested_dict['store']['address']['street'].or_else('No Address Specified')
         'No Address Specified'
+        >>> nested_dict['store']['address']['street'].or_none() is None
+        True
+        >>> nested_dict['store']['address']['street'].or_empty_list()
+        []
         >>> nested_dict['store']['departments']['sales']['head_count'].or_else('0')
         '10'
         >>> nested_dict['store']['departments']['marketing']['head_count'].or_else('0')

--- a/pymaybe/__init__.py
+++ b/pymaybe/__init__.py
@@ -6,6 +6,8 @@ __version__ = '0.2.0'
 
 from sys import getsizeof
 
+class NothingValueError(ValueError):
+    pass
 
 class Maybe(object):
     pass
@@ -19,7 +21,7 @@ class Nothing(Maybe):
         return True
 
     def get(self):
-        raise Exception('No such element')
+        raise NothingValueError('No such element')
 
     def or_else(self, els=None):
         if callable(els):
@@ -498,7 +500,7 @@ def maybe(value):
         >>> maybe(None).get()
         Traceback (most recent call last):
         ...
-        Exception: No such element
+        NothingValueError: No such element
 
         >>> maybe(None).or_else(lambda: "value")
         'value'

--- a/pymaybe/__init__.py
+++ b/pymaybe/__init__.py
@@ -96,10 +96,10 @@ class Nothing(Maybe):
 
     # region Custom representation
     def __repr__(self):
-        return repr(None)
+        return 'Nothing'
 
     def __str__(self):
-        return str(None)
+        return 'Nothing'
 
     def __unicode__(self):
         return unicode(None)
@@ -242,10 +242,10 @@ class Something(Maybe):
     # region Custom representation
 
     def __repr__(self):
-        return repr(self.__value)
+        return 'Something(%s)' % repr(self.__value)
 
     def __str__(self):
-        return str(self.__value)
+        return 'Something(%s)' % str(self.__value)
 
     def __int__(self):
         return int(self.__value)

--- a/pymaybe/__init__.py
+++ b/pymaybe/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = 'Eran Kampf'
 __email__ = 'eran@ekampf.com'
-__version__ = '0.1.7'
+__version__ = '0.2.0'
 
 from sys import getsizeof
 

--- a/tests/test_pymaybe.py
+++ b/tests/test_pymaybe.py
@@ -137,9 +137,6 @@ class TestPyMaybe(unittest.TestCase):
     def test_nothing_repr(self):
         self.assertEqual(repr(Nothing()), repr(None))
 
-    def test_nothing_str(self):
-        self.assertEqual(str(Nothing()), str(None))
-
     def test_nothing_unicode(self):
         if PY2:
             self.assertEqual(unicode(Nothing()), unicode(None))
@@ -159,8 +156,7 @@ class TestPyMaybe(unittest.TestCase):
         self.assertIsInstance(result, Nothing)
 
     def test_nothing_strings_returnNone(self):
-        n = Nothing()
-        self.assertEqual(str(n), str(None))
+        self.assertEqual(str(Nothing()), "Nothing")
 
     # endregion
 
@@ -256,10 +252,10 @@ class TestPyMaybe(unittest.TestCase):
             self.assertEqual(long(Something(n)), n)
             self.assertIsInstance(long(Something(f)), long)
 
-        self.assertEqual(str(Something(s)), s)
+        self.assertEqual(str(Something(s)), "Something(%s)" % s)
 
-        self.assertEqual(repr(Something(s)), repr(s))
-        self.assertEqual(repr(Something(d)), repr(d))
+        self.assertEqual(repr(Something(s)), "Something(%s)" % repr(s))
+        self.assertEqual(repr(Something(d)), "Something(%s)" % repr(d))
 
         self.assertEqual(int(Something(n)), n)
         self.assertIsInstance(int(Something(n)), int)

--- a/tests/test_pymaybe.py
+++ b/tests/test_pymaybe.py
@@ -20,8 +20,13 @@ PY3 = sys.version_info[0] == 3
 
 def load_tests(loader, tests, ignore):
     import pymaybe
-    tests.addTests(doctest.DocTestSuite(pymaybe,
-                                        globs=pymaybe.get_doctest_globs()))
+    tests.addTests(
+        doctest.DocTestSuite(
+            pymaybe,
+            globs=pymaybe.get_doctest_globs(),
+            optionflags=doctest.IGNORE_EXCEPTION_DETAIL
+        )
+    )
     return tests
 
 PY2 = sys.version_info[0] == 2

--- a/tests/test_pymaybe.py
+++ b/tests/test_pymaybe.py
@@ -134,9 +134,6 @@ class TestPyMaybe(unittest.TestCase):
 
     # region Nothing - Custom representation
 
-    def test_nothing_repr(self):
-        self.assertEqual(repr(Nothing()), repr(None))
-
     def test_nothing_unicode(self):
         if PY2:
             self.assertEqual(unicode(Nothing()), unicode(None))

--- a/tests/test_pymaybe.py
+++ b/tests/test_pymaybe.py
@@ -222,6 +222,8 @@ class TestPyMaybe(unittest.TestCase):
 
     def test_something_leValue_comparesTheUnderlyingValue(self):
         self.assertTrue(Something(1) < 2)
+        self.assertTrue(Something(1) <= 2)
+        self.assertTrue(Something(1) <= 1)
         self.assertFalse(Something(11) < 2)
 
     def test_something_geNothing_isTrue(self):
@@ -229,6 +231,8 @@ class TestPyMaybe(unittest.TestCase):
 
     def test_something_geSomething_comparesTheUnderlyingValue(self):
         self.assertTrue(Something(11) > Something(2))
+        self.assertTrue(Something(11) >= Something(2))
+        self.assertTrue(Something(11) >= Something(11))
         self.assertFalse(Something(1) > Something(2))
 
     def test_something_geValue_comparesTheUnderlyingValue(self):


### PR DESCRIPTION
Related to issue #5 

1. Fix `str` and `repr` methods to reflect value being wrapped
2. Add `or_none` and `or_empty_list` helper methods
3. Add custom exception when calling `get()` on a `Nothing`