### PR TITLE
Make `Maybe` a `Generic` type.

### DIFF
--- a/pymaybe/__init__.py
+++ b/pymaybe/__init__.py
@@ -5,15 +5,18 @@ __email__ = 'eran@ekampf.com'
 __version__ = '0.2.0'
 
 from sys import getsizeof
+from typing import Generic, TypeVar
+
+A = TypeVar("A")
 
 class NothingValueError(ValueError):
     pass
 
-class Maybe(object):
+class Maybe(Generic[A]):
     pass
 
 
-class Nothing(Maybe):
+class Nothing(Maybe[A]):
     def is_some(self):
         return False
 
@@ -118,7 +121,7 @@ class Nothing(Maybe):
     # endregion
 
 
-class Something(Maybe):
+class Something(Maybe[A]):
     def __init__(self, value):
         self.__value = value
 


### PR DESCRIPTION
Let me know if this needs any sort of testing or anything else.

One thing to note is that the `typing` module only exists in Python3.5+, so I'm not sure if there's version compatibility that needs to be maintained or not.

This may or may not also need a `__version__` bump.

@ekampf let me know. Thanks!